### PR TITLE
Stoch eos init fix

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -998,8 +998,10 @@ subroutine step_MOM_dynamics(forces, p_surf_begin, p_surf_end, dt, dt_thermo, &
   if (CS%stoch_eos_CS%use_stoch_eos) call MOM_stoch_eos_run(G,u,v,dt_thermo,Time_local,CS%stoch_eos_CS,CS%diag)
   call cpu_clock_end(id_clock_stoch)
   call cpu_clock_begin(id_clock_varT)
-  call MOM_calc_varT(G,GV,h,CS%tv,CS%stoch_eos_CS)
-  call pass_var(CS%tv%varT, G%Domain,clock=id_clock_pass,halo=1)
+  if (CS%stoch_eos_CS%stanley_coeff >= 0.0) then
+    call MOM_calc_varT(G,GV,h,CS%tv,CS%stoch_eos_CS)
+    call pass_var(CS%tv%varT, G%Domain,clock=id_clock_pass,halo=1)
+  endif	
   call cpu_clock_end(id_clock_varT)
 
   if ((CS%t_dyn_rel_adv == 0.0) .and. CS%thickness_diffuse .and. CS%thickness_diffuse_first) then

--- a/src/core/MOM_stoch_eos.F90
+++ b/src/core/MOM_stoch_eos.F90
@@ -69,7 +69,7 @@ contains
                  "SGS T variance.", default=1.0)
 				 
   !don't run anything if STANLEY_COEFF < 0
-  if (stoch_eos_CS%stanley_coeff >= 0.0)
+  if (stoch_eos_CS%stanley_coeff >= 0.0) then
   
     ALLOC_(stoch_eos_CS%pattern(G%isd:G%ied,G%jsd:G%jed)) ; stoch_eos_CS%pattern(:,:) = 0.0
     vd = var_desc("stoch_eos_pattern","nondim","Random pattern for stoch EOS",'h','1')


### PR DESCRIPTION
Don't calculate tv%varT if the scheme is turned off in the PGF and GM codes